### PR TITLE
Fixed Histogram Bug, Fixed Table Ratios

### DIFF
--- a/recommender.py
+++ b/recommender.py
@@ -263,7 +263,7 @@ def run_spark_jobs(dataset=None, num_predictions=None, rows=None, show_visualiza
         header_list = ["ASIN","Rating","Review Text","Review Time","Reviewer ID","Reviewer Name","Summary","Verified","Vote"]
 
         fig_table = go.Figure(data=[go.Table(
-            columnwidth=[75,50,150,85,100,100,90,50,40],
+            columnwidth=[65,45,175,80,95,95,100,50,35],
             header=dict(values=header_list,
                     fill_color=pts.get('header_color', None),
                     align='left',

--- a/vis.py
+++ b/vis.py
@@ -82,7 +82,7 @@ class Vis:
             xaxis_title="Ratings",
             yaxis_title="Review Count",
             bargap = 0.1,
-            margin=dict(l=180, r=180, t=0, b=0),
+            margin=dict(l=240, r=240, t=120, b=0),
         )
 
         fig.show()


### PR DESCRIPTION
1. Fixed the histogram so that the graph's title is properly shown.
2. Fixed the table ratios for the data set preview table so that more of the summary and review text are shown.